### PR TITLE
窗口交互调整、视觉颜色微调和文本修正。

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       --input-border-bottom: #8a8a8a;
 
       /* 7. 设置面板专用颜色 */
-      --settings-panel-bg: #E3E3E3;
+      --settings-panel-bg: #EEEEEE;
       --settings-card-bg: #ffffff;
       --settings-card-border: #e5e5e5;
       --settings-card-hover: #f9f9f9;
@@ -1426,7 +1426,7 @@
               <img id="profile-avatar" src="img/profiles.png" alt="头像" style="width: 48px; height: 48px; border-radius: 50%; object-fit: cover; background-color: var(--settings-thumb-bg); flex-shrink: 0; border: 2px solid var(--settings-card-border);">
               <div style="flex:1; min-width:0;">
               <div id="profile-name" style="font-weight: 600; font-size: 15px; color: var(--settings-text-primary);">个人</div>
-              <div id="profile-email" style="font-size: 13px; color: var(--settings-text-secondary);">本地账户</div>
+              <div id="profile-description" style="font-size: 13px; color: var(--settings-text-secondary);">本地账户</div>
               </div>
             </div>
 
@@ -1870,11 +1870,11 @@
         </div>
       </div>
 
-      <!-- 邮箱 -->
+      <!-- 描述 -->
       <div class="form-group">
-        <label class="form-label" for="input-profile-email" data-i18n="email">邮箱</label>
-        <div class="input-container" id="container-profile-email">
-          <input type="email" id="input-profile-email" class="input" placeholder="本地账户" autocomplete="off">
+        <label class="form-label" for="input-profile-description" data-i18n="description">描述</label>
+        <div class="input-container" id="container-profile-description">
+          <input type="text" id="input-profile-description" class="input" placeholder="本地账户" autocomplete="off">
         </div>
       </div> 
 

--- a/index.html
+++ b/index.html
@@ -1621,7 +1621,7 @@
             <!-- 底部版权/链接区域 -->
             <div class="settings-footer">
               <div class="settings-footer-links">
-                <a href="https://github.com/XingYueFox/Litestart/blob/main/PRIVACY_POLICY.md" data-i18n="cookieNotice">隐私与Cookie</a> · 
+                <a href="https://github.com/XingYueFox/Litestart/blob/main/PRIVACY_POLICY.md" data-i18n="cookieNotice">隐私与 Cookie</a> · 
                 <a href="https://github.com/XingYueFox/Litestart/blob/main/LICENSE" data-i18n="license">开源协议</a> ·  
                 <a href="https://github.com/XingYueFox/Litestart/graphs/contributors?from=2026%2F5%2F23" data-i18n="contributor">贡献名单</a> · 
                 <a href="https://github.com/XingYueFox/Litestart/issues" data-i18n="helpFeedback">帮助&反馈</a>
@@ -1925,9 +1925,9 @@
 <!-- 重置确认弹窗 -->
 <div id="modal-reset-confirm" class="modal-overlay">
   <div class="modal-dialog">
-    <div class="modal-header" data-i18n="resetTitle">重置Litestart</div>
+    <div class="modal-header" data-i18n="resetTitle">重置 Litestart</div>
     <div style="padding: 8px 0 16px 0; color: var(--neutral-foreground-rest); font-size: 14px; line-height: 1.6;">
-      <p style="margin: 0;" data-i18n="resetDesc">如果你遇到了一些问题，或是对于目前的设定不满意，重置可以清除所有数据并还原Litestart为初始状态，请注意，此操作不可撤回！</p>
+      <p style="margin: 0;" data-i18n="resetDesc">如果你遇到了一些问题，或是对于目前的设定不满意，重置可以清除所有数据并还原 Litestart 为初始状态，请注意，此操作不可撤回！</p>
     </div>
     <div class="modal-footer">
       <div class="modal-footer-right">

--- a/script.js
+++ b/script.js
@@ -102,7 +102,7 @@ const i18nData = {
     profileAvatar: '头像',
     uploadAvatar: '上传头像',
     removeAvatar: '删除头像',
-    email: '邮箱',
+    description: '描述',
 
     // 管理配置文件弹窗
     manageProfilesTitle: '管理配置文件',
@@ -189,7 +189,7 @@ const i18nData = {
     profileAvatar: '頭像',
     uploadAvatar: '上傳頭像',
     removeAvatar: '刪除頭像',
-    email: '電子郵件',
+    description: '描述',
     manageProfilesTitle: '管理設定檔',
     exportConfig: '匯出設定',
     importConfig: '還原設定',
@@ -270,7 +270,7 @@ const i18nData = {
     profileAvatar: '首像',
     uploadAvatar: '傳首像',
     removeAvatar: '去首像',
-    email: '郵箱',
+    description: '描述',
     manageProfilesTitle: '掌檔',
     exportConfig: '出設',
     importConfig: '入設',
@@ -352,7 +352,7 @@ const i18nData = {
     profileAvatar: 'Avatar',
     uploadAvatar: 'Upload Avatar',
     removeAvatar: 'Remove Avatar',
-    email: 'Email',
+    description: 'Description',
     manageProfilesTitle: 'Manage Profiles',
     exportConfig: 'Export Config',
     importConfig: 'Import Config',
@@ -434,7 +434,7 @@ const i18nData = {
     profileAvatar: 'アバター',
     uploadAvatar: 'アップロード',
     removeAvatar: '削除',
-    email: 'メール',
+    description: '説明',
     manageProfilesTitle: 'プロファイル管理',
     exportConfig: '設定をエクスポート',
     importConfig: '設定をインポート',
@@ -516,7 +516,7 @@ const i18nData = {
     profileAvatar: 'Аватар',
     uploadAvatar: 'Загрузить',
     removeAvatar: 'Удалить',
-    email: 'Почта',
+    description: 'Описание',
     manageProfilesTitle: 'Управление профилями',
     exportConfig: 'Экспорт настроек',
     importConfig: 'Импорт настроек',
@@ -1028,8 +1028,8 @@ document.addEventListener('DOMContentLoaded', () => {
 // ===== 用户个人资料管理 =====
 const defaultProfile = {
   name: '个人',
-  email: '本地账户',
-  avatar: 'img/profiles.png'  // 默认头像路径
+  description: '本地账户',
+  avatar: 'img/profiles.png'
 };
 
 // 加载或初始化用户资料
@@ -1043,11 +1043,11 @@ if (!userProfile) {
 function updateProfileUI() {
   const avatarImg = document.getElementById('profile-avatar');
   const nameEl = document.getElementById('profile-name');
-  const emailEl = document.getElementById('profile-email');
+  const descriptionEl = document.getElementById('profile-description');
 
   if (avatarImg) avatarImg.src = userProfile.avatar || defaultProfile.avatar;
   if (nameEl) nameEl.textContent = userProfile.name || defaultProfile.name;
-  if (emailEl) emailEl.textContent = userProfile.email || defaultProfile.email;
+  if (descriptionEl) descriptionEl.textContent = userProfile.description || defaultProfile.description;
   
 }
 
@@ -1057,7 +1057,7 @@ updateProfileUI();
 const modalProfile = document.getElementById('modal-profile');
 const profileForm = document.getElementById('profile-form');
 const inputProfileName = document.getElementById('input-profile-name');
-const inputProfileEmail = document.getElementById('input-profile-email');
+const inputProfileDescription = document.getElementById('input-profile-description');
 const profileAvatarPreview = document.getElementById('profile-avatar-preview');
 const btnUploadAvatar = document.getElementById('btn-upload-avatar');
 const inputAvatarFile = document.getElementById('input-avatar-file');
@@ -1070,7 +1070,7 @@ const btnProfileDetails = document.getElementById('btn-profile-details');
 function openProfileModal() {
   // 填充当前数据
   inputProfileName.value = userProfile.name || '';
-  inputProfileEmail.value = userProfile.email || '';
+  inputProfileDescription.value = userProfile.description || '';
   profileAvatarPreview.src = userProfile.avatar || defaultProfile.avatar;
   // 显示删除按钮条件：头像不是默认头像
   const isDefaultAvatar = userProfile.avatar === defaultProfile.avatar;
@@ -1120,17 +1120,12 @@ btnRemoveAvatar?.addEventListener('click', () => {
 // 取消按钮
 btnProfileCancel?.addEventListener('click', closeProfileModal);
 
-// 点击遮罩关闭
-modalProfile?.addEventListener('click', (e) => {
-  if (e.target === modalProfile) closeProfileModal();
-});
-
 // 提交表单保存
 profileForm?.addEventListener('submit', (e) => {
   e.preventDefault();
   // 获取各字段值
   const name = inputProfileName.value.trim() || defaultProfile.name;
-  const email = inputProfileEmail.value.trim() || defaultProfile.email;
+  const description = inputProfileDescription.value.trim() || defaultProfile.description;
 
   // 头像处理：若临时头像存在则使用，否则保留原有头像（如果用户未操作头像，则不变）
   let avatar = userProfile.avatar; // 默认使用原有
@@ -1146,7 +1141,7 @@ profileForm?.addEventListener('submit', (e) => {
 
   // 更新userProfile
   userProfile.name = name;
-  userProfile.email = email;
+  userProfile.description = description;
   userProfile.avatar = avatar;
 
   Storage.set('ntp_user_profile', userProfile);
@@ -1861,12 +1856,6 @@ function onDrop(e) {
   }
 
   btnCancel?.addEventListener('click', closeModal);
-
-  modalOverlay?.addEventListener('click', (e) => {
-    if (e.target === modalOverlay) {
-      closeModal();
-    }
-  });
 
   btnDelete?.addEventListener('click', () => {
     if (currentEditingId) {

--- a/script.js
+++ b/script.js
@@ -49,7 +49,7 @@ const i18nData = {
     editBackground: '编辑背景',
     language: '页面语言',
     langAuto: '默认（跟随设备）',
-    cookieNotice: '隐私与Cookie',
+    cookieNotice: '隐私与 Cookie',
     license: '开源协议',
     contributor: '贡献名单',
     helpFeedback: '帮助&反馈',
@@ -110,8 +110,8 @@ const i18nData = {
     importConfig: '恢复配置',
 
     // 重置确认弹窗
-    resetTitle: '重置Litestart',
-    resetDesc: '如果你遇到了一些问题，或是对于目前的设定不满意，重置可以清除所有数据并还原Litestart为初始状态，请注意，此操作不可撤回！',
+    resetTitle: '重置 Litestart',
+    resetDesc: '如果你遇到了一些问题，或是对于目前的设定不满意，重置可以清除所有数据并还原 Litestart 为初始状态，请注意，此操作不可撤回！',
     confirmReset: '确定',
 
     // 重置完成弹窗
@@ -193,8 +193,8 @@ const i18nData = {
     manageProfilesTitle: '管理設定檔',
     exportConfig: '匯出設定',
     importConfig: '還原設定',
-    resetTitle: '重設Litestart',
-    resetDesc: '如果你遇到了一些問題，或是對於目前的設定不滿意，重設可以清除所有數據並還原Litestart為初始狀態，請注意，此操作不可撤回！',
+    resetTitle: '重設 Litestart',
+    resetDesc: '如果你遇到了一些問題，或是對於目前的設定不滿意，重設可以清除所有數據並還原 Litestart 為初始狀態，請注意，此操作不可撤回！',
     confirmReset: '確定',
     resetDoneTitle: '重設完成',
     resetDoneDesc: '所有設定已重設為初始狀態，頁面即將重新整理。',
@@ -275,7 +275,7 @@ const i18nData = {
     exportConfig: '出設',
     importConfig: '入設',
     resetTitle: '復初',
-    resetDesc: '倘遭困顿，或厌时制，可复初以涤万设，返Litestart于鸿蒙。然此举不可追，慎之慎之！',
+    resetDesc: '倘遭困顿，或厌时制，可复初以涤万设，返 Litestart 于鸿蒙。然此举不可追，慎之慎之！',
     confirmReset: '定',
     resetDoneTitle: '妙哉！返本归元',
     resetDoneDesc: '万设归初，新页将启，天光焕然。',


### PR DESCRIPTION
**[调整]** 新增/编辑导航网址的窗口、编辑个人信息的窗口，点击其外部现**不可关闭**。因为容易误触，且这种可编辑内容的模态窗口误触代价更大，不应当点击外部关闭。

**[调整]** 微调了账户、设置浮窗在浅色模式下的背景颜色，使观感更佳。原先的颜色过深，与内容块对比过高，有些割裂感，不太和谐。

**[调整]** 将个人信息的“邮箱”字段改为“描述”字段。因为此处可随意自定义，且不具备邮箱相关功能，容易误导或限制用户填写内容。

**[调整]** 为部分语句的中英文之间增加空格，使之更符合规范。