### PR TITLE
调整背景图显示细节、跳转方式调整。

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,31 +168,34 @@
       object-fit: cover;
       display: none;
       opacity: 0;
-      transition: opacity 0.3s ease-in;
+      transition: opacity 0.2s ease-in;
     }
 
     #bg-video.loaded, #bg-image.loaded {
       opacity: 1;
     }
 
-    /* 暗角遮罩层：让壁纸中心明亮、四周变暗，提升前景文字可读性 */
+    /* 浅色模式下：中心透明、外围叠半透明白，柔化壁纸边缘让中心文字更清晰 */
     #bg-overlay {
       position: absolute;
       top: 0;
       left: 0;
       width: 100%;
       height: 100%;
-      /* 从中心向外：透明 → 半透明黑，柔化壁纸边缘 */
-      background: radial-gradient(circle at center, rgba(0,0,0,0) 30%, rgba(0,0,0,0.45) 100%);
+      background: radial-gradient(circle at center, rgba(255,255,255,0) 30%, rgba(255,255,255,0.40) 100%);
       display: none;
+      opacity: 0;
+      transition: opacity 0.2s ease-in;
     }
 
-    /* 暗色模式下叠加一层轻微的纵向渐变，让整体画面偏暗更协调 */
+    #bg-overlay.loaded {
+      opacity: 1;
+    }
+
+    /* 暗色模式下：中心透明、外围叠半透明黑，让整体画面偏暗更协调 */
     @media (prefers-color-scheme: dark) {
       body.bg-enabled #bg-overlay {
-        background: 
-          linear-gradient(rgba(0, 0, 0, 0.20), rgba(0, 0, 0, 0.15)),
-          radial-gradient(circle at center, rgba(0,0,0,0) 30%, rgba(0,0,0,0.45) 100%);
+        background: radial-gradient(circle at center, rgba(0,0,0,0) 30%, rgba(0,0,0,0.45) 100%);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
       left: 0;
       width: 100%;
       height: 100%;
-      background: radial-gradient(circle at center, rgba(255,255,255,0) 30%, rgba(255,255,255,0.40) 100%);
+      background: radial-gradient(circle at center, rgba(255,255,255,0) 55%, rgba(255,255,255,0.40) 100%);
       display: none;
       opacity: 0;
       transition: opacity 0.2s ease-in;
@@ -195,7 +195,7 @@
     /* 暗色模式下：中心透明、外围叠半透明黑，让整体画面偏暗更协调 */
     @media (prefers-color-scheme: dark) {
       body.bg-enabled #bg-overlay {
-        background: radial-gradient(circle at center, rgba(0,0,0,0) 30%, rgba(0,0,0,0.45) 100%);
+        background: radial-gradient(circle at center, rgba(0,0,0,0) 55%, rgba(0,0,0,0.45) 100%);
       }
     }
 

--- a/script.js
+++ b/script.js
@@ -1187,11 +1187,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 在GitHub中查看按钮跳转
   document.getElementById('btn-github')?.addEventListener('click', () => {
     const url = 'https://github.com/XingYueFox/Litestart';
-    if (typeof chrome !== 'undefined' && chrome.tabs && chrome.tabs.create) {
-      chrome.tabs.create({ url });
-    } else {
-      window.open(url, '_blank');
-    }
+    window.location.href = url;
   });
 
   // 点击遮罩层关闭
@@ -2139,7 +2135,6 @@ inputOnlineUrl?.addEventListener('input', () => {
     const linkElem = document.createElement('a');
     linkElem.href = item.url;
     linkElem.className = 'quicklink-item';
-    linkElem.target = '_blank';
     linkElem.setAttribute('data-id', item.id);
 
     const safeTitle = sanitizeInput(item.title);

--- a/script.js
+++ b/script.js
@@ -1173,6 +1173,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const bgVideo = document.getElementById('bg-video');
   const bgImage = document.getElementById('bg-image');
+  const bgOverlay = document.getElementById('bg-overlay');
 
   // 关于弹窗
   document.getElementById('btn-about')?.addEventListener('click', () => {
@@ -1456,6 +1457,9 @@ document.addEventListener('DOMContentLoaded', () => {
         bgImage.classList.remove('loaded');
         bgImage.style.display = 'none';
       }
+      if (bgOverlay) {
+        bgOverlay.classList.remove('loaded');
+      }
       if (enhancedVisibility) {
         enhancedVisibility = false;
         Storage.set('ntp_enhanced_visibility', false);
@@ -1511,6 +1515,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // 默认背景加载完成后渐入
         bgImage.addEventListener('load', function onDefLoad() {
           bgImage.classList.add('loaded');
+          bgOverlay?.classList.add('loaded');
           bgImage.removeEventListener('load', onDefLoad);
         });
       }
@@ -1544,6 +1549,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // 视频缓冲到可播放时再渐入
         const onCanPlay = () => {
           bgVideo.classList.add('loaded');
+          bgOverlay?.classList.add('loaded');
           bgVideo.removeEventListener('canplay', onCanPlay);
           bgVideo.play().catch(() => {});
         };
@@ -1567,10 +1573,12 @@ document.addEventListener('DOMContentLoaded', () => {
         // 图片加载完成后渐入；complete 为 true 表示浏览器缓存已命中，直接显示
         const onLoad = () => {
           bgImage.classList.add('loaded');
+          bgOverlay?.classList.add('loaded');
           bgImage.removeEventListener('load', onLoad);
         };
         if (bgImage.complete && bgImage.naturalWidth > 0) {
           bgImage.classList.add('loaded');
+          bgOverlay?.classList.add('loaded');
         } else {
           bgImage.addEventListener('load', onLoad);
         }


### PR DESCRIPTION
[调整] 缩短背景图渐显时间到0.2s（之前太慢，略显拖沓）
[调整] 浅色模式下背景图暗角遮罩变为亮角。（更符合浅色模式观感，同时避免黑底黑图标）
[调整] 背景图附带的暗角（亮角）遮罩现在与背景图同时出现，而不是始终存在。（背景图未加载好时是干净的纯色背景）
[调整] 微调暗角（亮角）尺寸。